### PR TITLE
Make it possible to deploy from live site to staging without alias do…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
 - include: composer_update_task.yml
   when: new_site_enabled|success
 - include: move_site_alias.yml
-  when: new_site_enabled|success
+  when: (new_site_enabled|success and move_site_alias)
   notify:
    - Retart Apache
 ...


### PR DESCRIPTION
…main actions

ansible-playbook -i hosts -u aegir deploy.yml --flush-cache  -e "destination=staging alias_old_platform=<OldLivePlatform> alias_old_site=<OldLiveSite> move_site_alias=false"